### PR TITLE
Correcting the syntax for Pointclouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ To construct a point cloud, use the `PointCloud` class:
 ```python
 points = ...  # 1 x N x 3
 rgb = ...  # 1 x N x 3
-point_cloud = pytorch3d.structures.PointCloud(
+point_cloud = pytorch3d.structures.Pointclouds(
     points=points, features=rgb
 )
 ```


### PR DESCRIPTION
In Section 5 Rendering Generic 3D representations, there is an error in defining Pointclouds using pytorch3d. 
I request the instructors to fix this.

Thanks,
Rohit  